### PR TITLE
Remove config merge

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,5 @@ var defaults = require('./defaults');
 
 module.exports = function(config) {
 
-  config = _.merge(defaults, config);
-
   return require('./lib/manifestHelper')(config);
 };


### PR DESCRIPTION
Changed this because I don't need the default manifest and
this allows multiple 'app.use(manifest{ … })' to set up
multiple projects that have manifests within express.